### PR TITLE
Unify strides of `o` and `do` in attention backward

### DIFF
--- a/dkernel/ops/sparse_attn_bwd.py
+++ b/dkernel/ops/sparse_attn_bwd.py
@@ -637,6 +637,16 @@ def _backward(ctx,
     layout_crow_indices, layout_col_indices, dq_block_m, dq_block_n = ctx.layout_csr
     layout_ccol_indices, layout_row_indices, dk_block_m, dk_block_n = ctx.layout_csc
 
+    # See https://github.com/NVIDIA/Megatron-LM/blob/core_r0.9.0/megatron/core/extensions/transformer_engine.py#L557
+    # In PyTorch, the following two tensors are in fact the same:
+    #   Tensor with shape (1, S, H, D) and stride (S*H*D, H*D, D, 1)
+    #   Tensor with shape (1, S, H, D) and stride (H*D, H*D, D, 1)
+    # Stride for a dimension that is 1 has no meaning, so tensors created two different ways
+    # can have same shape but different strides.
+    # We unify them to the first one to pass the stride check
+    if o.shape == do.shape and o.shape[0] == 1 and o.stride() != do.stride():
+        do = do.as_strided(o.shape, o.stride())
+                  
     if not do.is_contiguous():
         # TODO: is it necessary to have non-contiguous layout
         do = do.contiguous()


### PR DESCRIPTION
When performing backward propagation, `o` and `do` will sometimes have different strides and fail the stride check:

https://github.com/linxihui/dkernel/blob/main/dkernel/ops/sparse_attn_bwd.py#L675 

This is true when training a model with GQA, where the key and value need to be repeated before passing to the kernel. When passing in `q`, `k` and `v` with size `[B, S, H, D]` and stride `[S*H*D, H*D, D, 1]` where `B == 1,` the output `o` has the same size and stride, but `do` has stride `[H*D, H*D, D, 1]`. I have not tested training a model without GQA.

According to [this attention implementation of Megatron-LM](https://github.com/NVIDIA/Megatron-LM/blob/core_r0.9.0/megatron/core/extensions/transformer_engine.py#L557), stride for a dimension that is 1 has no meaning, so the two strides mean the same thing. We adapt their solution to pass the stride check here.